### PR TITLE
fix: relax pandas dep from exact pin to a range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 15:23 on 19-03-2024
+
+- Locked all package versions in setup.py and requirements.txt:
+  - python-binance==1.0.28
+  - pandas==2.2.3
+  - numpy==1.26.4
+  - wrangle==0.7.6
+  - tqdm==4.67.1
+  - xgboost==2.0.3
+  - scikit-learn==1.4.1.post1
+
+## 14:45 on 14-08-2024
+
+- Enhanced `get_trades_historical` function to support retrieving any number of trades using ID-based pagination
+  - Added functionality to make multiple API calls when limit exceeds 1000
+  - Maintains backward compatibility with existing implementation
+  - Improved documentation to reflect new capability
+
 ## v0.2.0
 
 - Added `compute` module with `get_spot_klines` — builds 19-column klines from raw trades with OHLC, statistical measures, volume, maker metrics, and liquidity metrics
@@ -18,24 +36,8 @@
 - Added `nest_asyncio` to dependencies
 - 38 tests, 95%+ coverage
 
-## 14:45 on 14-08-2024
-
-- Enhanced `get_trades_historical` function to support retrieving any number of trades using ID-based pagination
-  - Added functionality to make multiple API calls when limit exceeds 1000
-  - Maintains backward compatibility with existing implementation
-  - Improved documentation to reflect new capability
-
-## 15:23 on 19-03-2024
-
-- Locked all package versions in setup.py and requirements.txt:
-  - python-binance==1.0.28
-  - pandas==2.2.3
-  - numpy==1.26.4
-  - wrangle==0.7.6
-  - tqdm==4.67.1
-  - xgboost==2.0.3
-  - scikit-learn==1.4.1.post1
-
 ## v0.2.1
 
 - Relax the `pandas` dependency from the exact pin `pandas==2.2.3` to `pandas>=2.2.3,<3`. Binancial is used alongside `vaquum-limen` (currently `pandas>=2.3.1`) inside `vaquum-praxis`; with the exact pin, `pip` / `uv` couldn't satisfy both constraints and Praxis's CI dependency resolution was failing. A library-style range lets consumers resolve Binancial and Limen together without code change on either side.
+- Sync runtime `__version__` in `binancial/__init__.py` with `pyproject.toml` (`0.2.0` → `0.2.1`) so both report the same version
+- Reorder CHANGELOG to oldest-first / newest-at-bottom, matching the `vaquum-limen` / `vaquum-nexus` / `vaquum-praxis` convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,7 @@
   - tqdm==4.67.1
   - xgboost==2.0.3
   - scikit-learn==1.4.1.post1
+
+## v0.2.1
+
+- Relax the `pandas` dependency from the exact pin `pandas==2.2.3` to `pandas>=2.2.3,<3`. Binancial is used alongside `vaquum-limen` (currently `pandas>=2.3.1`) inside `vaquum-praxis`; with the exact pin, `pip` / `uv` couldn't satisfy both constraints and Praxis's CI dependency resolution was failing. A library-style range lets consumers resolve Binancial and Limen together without code change on either side.

--- a/binancial/__init__.py
+++ b/binancial/__init__.py
@@ -2,4 +2,4 @@ from . import compute as compute
 from . import data as data
 from . import utils as utils
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "binancial"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Binance API-wrapper that brings all klines and trades data end-points to single-line commands."
 readme = "README.md"
 license = {text = "MIT"}
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "python-binance==1.0.28",
-    "pandas==2.2.3",
+    "pandas>=2.2.3,<3",
     "numpy==1.26.4",
     "wrangle==0.7.6",
     "tqdm==4.67.1",


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Replaces the exact dependency `pandas==2.2.3` in \`pyproject.toml\` with the library-style range `pandas>=2.2.3,<3`. The exact pin made Binancial impossible to co-install with \`vaquum-limen\` (currently \`pandas>=2.3.1\`), which breaks \`vaquum-praxis\`'s dependency resolution — Praxis pulls both libraries as git-sourced dependencies, and \`pip\` / \`uv\` can't satisfy an exact \`2.2.3\` pin alongside Limen's \`>=2.3.1\` floor. CI on Praxis's open PR #72 was failing at the \`pip install\` step for exactly this reason.

A range is the right shape for a library (apps pin exactly, libraries use ranges). Binancial's actual pandas usage is stable across pandas 2.x — DataFrame construction and named-column selection in \`get_spot_klines\` and \`get_trades_historical\` — and there is no known incompatibility with the 2.3.x line. The \`<3\` guard avoids silently pulling in a future pandas 3.x that could break column or dtype semantics.

Bumps version to 0.2.1 and documents the change in CHANGELOG.md.

Fixes the \`pip\` resolution blocker seen in Praxis PR #72.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python tests/run.py\` locally without errors (where applicable)
- [ ] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable