### PR TITLE
fix: relax all remaining exact dep pins to library-style ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   - `wrangle==0.7.6` → `wrangle>=0.7.6,<1`
   - `tqdm==4.67.1` → `tqdm>=4.67.0,<5` (floor lowered to match Limen)
   - `xgboost==2.0.3` → `xgboost>=2.0.3,<3`
-  - `scikit-learn==1.4.1.post1` → `scikit-learn>=1.4.1,<2` (Limen's `>=1.6.1` still resolves; `<2` guards against a future 2.x breaking release for consistency with the other caps)
+  - `scikit-learn==1.4.1.post1` → `scikit-learn>=1.4.1.post1,<2` (Limen's `>=1.6.1` still resolves; `<2` guards against a future 2.x breaking release for consistency with the other caps)
   - `nest_asyncio==1.6.0` → `nest_asyncio>=1.6.0,<2`
   - `pandas` was already a range since v0.2.1
 - Bump `__version__` and `pyproject.toml` version to 0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   - `wrangle==0.7.6` → `wrangle>=0.7.6,<1`
   - `tqdm==4.67.1` → `tqdm>=4.67.0,<5` (floor lowered to match Limen)
   - `xgboost==2.0.3` → `xgboost>=2.0.3,<3`
-  - `scikit-learn==1.4.1.post1` → `scikit-learn>=1.4.1` (no upper cap so Limen's `>=1.6.1` resolves)
+  - `scikit-learn==1.4.1.post1` → `scikit-learn>=1.4.1,<2` (Limen's `>=1.6.1` still resolves; `<2` guards against a future 2.x breaking release for consistency with the other caps)
   - `nest_asyncio==1.6.0` → `nest_asyncio>=1.6.0,<2`
   - `pandas` was already a range since v0.2.1
 - Bump `__version__` and `pyproject.toml` version to 0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,16 @@
 - Relax the `pandas` dependency from the exact pin `pandas==2.2.3` to `pandas>=2.2.3,<3`. Binancial is used alongside `vaquum-limen` (currently `pandas>=2.3.1`) inside `vaquum-praxis`; with the exact pin, `pip` / `uv` couldn't satisfy both constraints and Praxis's CI dependency resolution was failing. A library-style range lets consumers resolve Binancial and Limen together without code change on either side.
 - Sync runtime `__version__` in `binancial/__init__.py` with `pyproject.toml` (`0.2.0` → `0.2.1`) so both report the same version
 - Reorder CHANGELOG to oldest-first / newest-at-bottom, matching the `vaquum-limen` / `vaquum-nexus` / `vaquum-praxis` convention
+
+## v0.2.2
+
+- Relax all remaining exact dependency pins to library-style ranges so Binancial can co-install with other Vaquum libraries (notably `vaquum-limen`) inside downstream applications. Every dep now uses a lower bound at the previously-pinned version with a conservative major-version upper cap where applicable:
+  - `python-binance==1.0.28` → `python-binance>=1.0.28,<2`
+  - `numpy==1.26.4` → `numpy>=1.26.4,<3` (allows numpy 2.x, which Limen requires)
+  - `wrangle==0.7.6` → `wrangle>=0.7.6,<1`
+  - `tqdm==4.67.1` → `tqdm>=4.67.0,<5` (floor lowered to match Limen)
+  - `xgboost==2.0.3` → `xgboost>=2.0.3,<3`
+  - `scikit-learn==1.4.1.post1` → `scikit-learn>=1.4.1` (no upper cap so Limen's `>=1.6.1` resolves)
+  - `nest_asyncio==1.6.0` → `nest_asyncio>=1.6.0,<2`
+  - `pandas` was already a range since v0.2.1
+- Bump `__version__` and `pyproject.toml` version to 0.2.2

--- a/binancial/__init__.py
+++ b/binancial/__init__.py
@@ -2,4 +2,4 @@ from . import compute as compute
 from . import data as data
 from . import utils as utils
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "wrangle>=0.7.6,<1",
     "tqdm>=4.67.0,<5",
     "xgboost>=2.0.3,<3",
-    "scikit-learn>=1.4.1",
+    "scikit-learn>=1.4.1,<2",
     "nest_asyncio>=1.6.0,<2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "wrangle>=0.7.6,<1",
     "tqdm>=4.67.0,<5",
     "xgboost>=2.0.3,<3",
-    "scikit-learn>=1.4.1,<2",
+    "scikit-learn>=1.4.1.post1,<2",
     "nest_asyncio>=1.6.0,<2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "binancial"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Binance API-wrapper that brings all klines and trades data end-points to single-line commands."
 readme = "README.md"
 license = {text = "MIT"}
@@ -13,14 +13,14 @@ authors = [
     {name = "Mikko Kotila"},
 ]
 dependencies = [
-    "python-binance==1.0.28",
+    "python-binance>=1.0.28,<2",
     "pandas>=2.2.3,<3",
-    "numpy==1.26.4",
-    "wrangle==0.7.6",
-    "tqdm==4.67.1",
-    "xgboost==2.0.3",
-    "scikit-learn==1.4.1.post1",
-    "nest_asyncio==1.6.0",
+    "numpy>=1.26.4,<3",
+    "wrangle>=0.7.6,<1",
+    "tqdm>=4.67.0,<5",
+    "xgboost>=2.0.3,<3",
+    "scikit-learn>=1.4.1",
+    "nest_asyncio>=1.6.0,<2",
 ]
 
 [project.urls]


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Finishes the work started in #19. After that PR relaxed \`pandas==2.2.3\` to \`pandas>=2.2.3,<3\`, Praxis CI surfaced the next blocker: \`scikit-learn==1.4.1.post1\` in Binancial vs \`scikit-learn>=1.6.1\` in \`vaquum-limen\`. The same pattern would keep repeating across \`numpy\`, \`xgboost\`, \`tqdm\`, etc., because Binancial was pinning every dependency to an exact version — correct for an application, but not for a library that other Vaquum libraries co-install with.

Relax all remaining exact pins to library-style ranges. Each dep keeps its previous version as the lower bound and adds a conservative major-version upper cap where applicable:

| Dep | Before | After |
|---|---|---|
| \`python-binance\` | \`==1.0.28\` | \`>=1.0.28,<2\` |
| \`numpy\` | \`==1.26.4\` | \`>=1.26.4,<3\` (allows 2.x, which Limen requires via \`numpy>=2.2.6\`) |
| \`wrangle\` | \`==0.7.6\` | \`>=0.7.6,<1\` |
| \`tqdm\` | \`==4.67.1\` | \`>=4.67.0,<5\` (floor lowered to match Limen's \`>=4.67.0\`) |
| \`xgboost\` | \`==2.0.3\` | \`>=2.0.3,<3\` |
| \`scikit-learn\` | \`==1.4.1.post1\` | \`>=1.4.1.post1,<2\` (Limen's \`>=1.6.1\` still resolves; \`<2\` guards against a future 2.x breaking release for consistency with the other caps) |
| \`nest_asyncio\` | \`==1.6.0\` | \`>=1.6.0,<2\` |
| \`pandas\` | (range since v0.2.1) | (unchanged) |

**Verification:** re-installed under the new ranges locally — the resolver picked \`scikit-learn==1.8.0\` and \`numpy==2.4.4\` (Limen's floors) and all 38 tests pass. Binancial does not import \`scikit-learn\`, \`xgboost\`, \`tqdm\`, or \`nest_asyncio\` directly anywhere in \`binancial/\`; the only direct imports are \`pandas\`, \`numpy\`, \`wrangle\`, and \`python-binance\`. No code changes — deps-only PR.

Bumps version to 0.2.2 and syncs \`__version__\`.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python tests/run.py\` locally without errors (where applicable)
- [x] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable
