### PR TITLE
feat: SpotKlineCache for incremental trade-history pagination (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.0
+
+- Added `SpotKlineCache` ([`binancial/compute/spot_kline_cache.py`](binancial/compute/spot_kline_cache.py)) — stateful kline cache that pulls only NEW trades since the last cached `trade_id` on every fetch after the initial backfill. Drops per-fetch network cost from hundreds of paginated calls to ~1
+- Added `last_trade_id` parameter to [`get_trades_historical`](binancial/data/get_trades_historical.py); mutually exclusive with `start_date`. Backwards-compatible
+- Added 8 new tests; 49 total, all passing
+
 ## 15:23 on 19-03-2024
 
 - Locked all package versions in setup.py and requirements.txt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v0.3.0
-
-- Added `SpotKlineCache` ([`binancial/compute/spot_kline_cache.py`](binancial/compute/spot_kline_cache.py)) — stateful kline cache that pulls only NEW trades since the last cached `trade_id` on every fetch after the initial backfill. Drops per-fetch network cost from hundreds of paginated calls to ~1
-- Added `last_trade_id` parameter to [`get_trades_historical`](binancial/data/get_trades_historical.py); mutually exclusive with `start_date`. Backwards-compatible
-- Added 8 new tests; 49 total, all passing
-
 ## 15:23 on 19-03-2024
 
 - Locked all package versions in setup.py and requirements.txt:
@@ -60,3 +54,9 @@
   - `nest_asyncio==1.6.0` → `nest_asyncio>=1.6.0,<2`
   - `pandas` was already a range since v0.2.1
 - Bump `__version__` and `pyproject.toml` version to 0.2.2
+
+## v0.3.0
+
+- Added `SpotKlineCache` ([`binancial/compute/spot_kline_cache.py`](binancial/compute/spot_kline_cache.py)) — stateful kline cache that pulls only NEW trades since the last cached `trade_id` on every fetch after the initial backfill. Drops per-fetch network cost from hundreds of paginated calls to ~1
+- Added `last_trade_id` parameter to [`get_trades_historical`](binancial/data/get_trades_historical.py); mutually exclusive with `start_date`. Backwards-compatible
+- Added 8 new tests; 49 total, all passing

--- a/binancial/__init__.py
+++ b/binancial/__init__.py
@@ -2,4 +2,4 @@ from . import compute as compute
 from . import data as data
 from . import utils as utils
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/binancial/compute/__init__.py
+++ b/binancial/compute/__init__.py
@@ -1,2 +1,4 @@
+from .get_spot_klines import aggregate_trades as aggregate_trades
+from .get_spot_klines import drop_partial_kline as drop_partial_kline
 from .get_spot_klines import get_spot_klines as get_spot_klines
 from .spot_kline_cache import SpotKlineCache as SpotKlineCache

--- a/binancial/compute/__init__.py
+++ b/binancial/compute/__init__.py
@@ -1,1 +1,2 @@
 from .get_spot_klines import get_spot_klines as get_spot_klines
+from .spot_kline_cache import SpotKlineCache as SpotKlineCache

--- a/binancial/compute/get_spot_klines.py
+++ b/binancial/compute/get_spot_klines.py
@@ -54,7 +54,7 @@ def _build_chunks(start_date: str, end_date: str, n_chunks: int) -> list[tuple[s
     return chunks
 
 
-def _aggregate_trades(trades: pd.DataFrame, kline_size: int) -> pd.DataFrame:
+def aggregate_trades(trades: pd.DataFrame, kline_size: int) -> pd.DataFrame:
     '''Aggregate raw trades into klines.'''
 
     if trades.empty:
@@ -120,7 +120,7 @@ def _aggregate_trades(trades: pd.DataFrame, kline_size: int) -> pd.DataFrame:
     return df
 
 
-def _drop_partial_kline(df: pd.DataFrame) -> pd.DataFrame:
+def drop_partial_kline(df: pd.DataFrame) -> pd.DataFrame:
     '''Drop the last kline row which may be partial (trades still arriving).'''
     if len(df) > 0:
         return df.iloc[:-1].reset_index(drop=True)
@@ -156,7 +156,7 @@ def get_spot_klines(client: Any,
             client, symbol=symbol, limit=10_000_000,
             start_date=start_date, end_date=end_date,
         )
-        return _drop_partial_kline(_aggregate_trades(trades, kline_size))
+        return drop_partial_kline(aggregate_trades(trades, kline_size))
 
     chunks = _build_chunks(start_date, end_date, workers)
 
@@ -178,4 +178,4 @@ def get_spot_klines(client: Any,
     trades = pd.concat(frames, ignore_index=True)
     trades = trades.drop_duplicates(subset='trade_id').sort_values('trade_id').reset_index(drop=True)
 
-    return _drop_partial_kline(_aggregate_trades(trades, kline_size))
+    return drop_partial_kline(aggregate_trades(trades, kline_size))

--- a/binancial/compute/spot_kline_cache.py
+++ b/binancial/compute/spot_kline_cache.py
@@ -1,0 +1,127 @@
+'''Stateful spot kline cache with incremental trade-history pagination.
+
+Maintains a rolling buffer of raw trades and aggregates them into
+klines on each `fetch()`. The first call backfills from
+`now - n_rows * kline_size`; subsequent calls only pull NEW trades
+since the last cached `trade_id`. Collapses per-fetch network cost
+from hundreds of paginated `/api/v3/historicalTrades` calls (one per
+1000 trades over the full window) to ~1 call per fetch (the few
+hundred trades arrived since the previous fetch).
+'''
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pandas as pd
+
+from ..data import get_trades_historical
+from .get_spot_klines import _aggregate_trades, _drop_partial_kline
+
+_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
+_PAGINATION_LIMIT = 10_000_000
+
+
+class SpotKlineCache:
+
+    '''Rolling kline cache backed by an incremental raw-trade buffer.
+
+    client | init_binance_api | historical client object
+    symbol | str | ticker symbol e.g. 'BTCUSDT'
+    kline_size | int | kline period size in seconds
+    n_rows | int | rolling buffer depth in klines (the trade buffer
+                   is trimmed so its time span never exceeds
+                   `n_rows * kline_size` seconds after each fetch)
+    '''
+
+    def __init__(self,
+                 client: Any,
+                 symbol: str = 'BTCUSDT',
+                 kline_size: int = 300,
+                 n_rows: int = 1100) -> None:
+
+        if kline_size <= 0:
+            raise ValueError(f'kline_size must be positive, got {kline_size}')
+
+        if n_rows <= 0:
+            raise ValueError(f'n_rows must be positive, got {n_rows}')
+
+        self._client = client
+        self._symbol = symbol
+        self._kline_size = kline_size
+        self._n_rows = n_rows
+        self._trades: pd.DataFrame = pd.DataFrame()
+
+    @property
+    def cached_trade_count(self) -> int:
+        '''Number of raw trades currently held in the rolling buffer.'''
+
+        return len(self._trades)
+
+    @property
+    def last_trade_id(self) -> int | None:
+        '''Highest `trade_id` in the rolling buffer, or `None` if empty.'''
+
+        if self._trades.empty:
+            return None
+
+        return int(self._trades['trade_id'].max())
+
+    def fetch(self) -> pd.DataFrame:
+
+        '''Pull new trades since the last fetch, aggregate, return klines.
+
+        On the first call, backfills the trade buffer from
+        `now - n_rows * kline_size` via `get_trades_historical`'s
+        `start_date` path. On every subsequent call, pulls only trades
+        with `trade_id > self.last_trade_id` via the new
+        `last_trade_id` path. The buffer is trimmed back to the
+        `n_rows * kline_size` time window after each append, so memory
+        stays bounded.
+
+        Returns:
+            pd.DataFrame: 19-column klines aggregated from the current
+                buffer, with the trailing partial kline dropped.
+        '''
+
+        if self._trades.empty:
+            start = (
+                dt.datetime.now(tz=dt.UTC)
+                - dt.timedelta(seconds=self._n_rows * self._kline_size)
+            ).strftime(_DATETIME_FMT)
+            self._trades = get_trades_historical(
+                self._client,
+                symbol=self._symbol,
+                limit=_PAGINATION_LIMIT,
+                start_date=start,
+            )
+        else:
+            new_trades = get_trades_historical(
+                self._client,
+                symbol=self._symbol,
+                limit=_PAGINATION_LIMIT,
+                last_trade_id=int(self._trades['trade_id'].max()),
+            )
+
+            if not new_trades.empty:
+                self._trades = pd.concat(
+                    [self._trades, new_trades], ignore_index=True,
+                )
+                self._trim_cache()
+
+        return _drop_partial_kline(_aggregate_trades(self._trades, self._kline_size))
+
+    def _trim_cache(self) -> None:
+
+        '''Drop trades older than `n_rows * kline_size` seconds.'''
+
+        if self._trades.empty:
+            return
+
+        cutoff = self._trades['time'].max() - pd.Timedelta(
+            seconds=self._n_rows * self._kline_size,
+        )
+        self._trades = self._trades[
+            self._trades['time'] >= cutoff
+        ].reset_index(drop=True)

--- a/binancial/compute/spot_kline_cache.py
+++ b/binancial/compute/spot_kline_cache.py
@@ -12,12 +12,12 @@ hundred trades arrived since the previous fetch).
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
 from ..data import get_trades_historical
-from .get_spot_klines import _aggregate_trades, _drop_partial_kline
+from .get_spot_klines import aggregate_trades, drop_partial_kline
 
 _DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
 _PAGINATION_LIMIT = 10_000_000
@@ -110,7 +110,7 @@ class SpotKlineCache:
                 )
                 self._trim_cache()
 
-        return _drop_partial_kline(_aggregate_trades(self._trades, self._kline_size))
+        return drop_partial_kline(aggregate_trades(self._trades, self._kline_size))
 
     def _trim_cache(self) -> None:
 
@@ -122,6 +122,8 @@ class SpotKlineCache:
         cutoff = self._trades['time'].max() - pd.Timedelta(
             seconds=self._n_rows * self._kline_size,
         )
-        self._trades = self._trades[
-            self._trades['time'] >= cutoff
-        ].reset_index(drop=True)
+        filtered = cast(
+            pd.DataFrame,
+            self._trades[self._trades['time'] >= cutoff],
+        )
+        self._trades = filtered.reset_index(drop=True)

--- a/binancial/compute/spot_kline_cache.py
+++ b/binancial/compute/spot_kline_cache.py
@@ -77,8 +77,11 @@ class SpotKlineCache:
         `start_date` path. On every subsequent call, pulls only trades
         with `trade_id > self.last_trade_id` via the new
         `last_trade_id` path. The buffer is trimmed back to the
-        `n_rows * kline_size` time window after each append, so memory
-        stays bounded.
+        `n_rows * kline_size` time window after every fetch (including
+        the initial backfill, which can overshoot when
+        `_resolve_start_id` snaps to the first trade at-or-after the
+        cutoff and pagination pulls a final batch past the window),
+        so memory stays bounded from the first call onward.
 
         Returns:
             pd.DataFrame: 19-column klines aggregated from the current
@@ -108,7 +111,8 @@ class SpotKlineCache:
                 self._trades = pd.concat(
                     [self._trades, new_trades], ignore_index=True,
                 )
-                self._trim_cache()
+
+        self._trim_cache()
 
         return drop_partial_kline(aggregate_trades(self._trades, self._kline_size))
 

--- a/binancial/compute/tests/test_get_spot_klines.py
+++ b/binancial/compute/tests/test_get_spot_klines.py
@@ -8,9 +8,9 @@ import pytest
 
 from binancial.compute.get_spot_klines import (
     KLINE_COLUMNS,
-    _aggregate_trades,
     _build_chunks,
     _parse_datetime,
+    aggregate_trades,
     get_spot_klines,
 )
 
@@ -71,7 +71,7 @@ class TestParseDatetime:
 
 
 # ---------------------------------------------------------------------------
-# _aggregate_trades
+# aggregate_trades
 # ---------------------------------------------------------------------------
 
 class TestAggregateTrades:
@@ -79,7 +79,7 @@ class TestAggregateTrades:
     def test_empty_input(self):
         empty = pd.DataFrame(columns=['time', 'trade_id', 'price', 'quantity',
                                        'quote_quantity', 'buyer_is_maker'])
-        result = _aggregate_trades(empty, kline_size=1)
+        result = aggregate_trades(empty, kline_size=1)
         assert list(result.columns) == KLINE_COLUMNS
         assert len(result) == 0
 
@@ -94,7 +94,7 @@ class TestAggregateTrades:
             maker_flags=[True, False, True, False],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
 
         assert len(result) == 1
         row = result.iloc[0]
@@ -126,7 +126,7 @@ class TestAggregateTrades:
             maker_flags=[True, True, False, False],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
 
         assert len(result) == 2
         # First bucket
@@ -151,7 +151,7 @@ class TestAggregateTrades:
             maker_flags=[True, False, True],
         )
 
-        result = _aggregate_trades(trades, kline_size=60)
+        result = aggregate_trades(trades, kline_size=60)
         assert len(result) == 1
         assert result.iloc[0]['no_of_trades'] == 3
 
@@ -169,7 +169,7 @@ class TestAggregateTrades:
             maker_flags=[False, False],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
         assert result.iloc[0]['open'] == 111.0   # trade_id 5 (min)
         assert result.iloc[0]['close'] == 999.0  # trade_id 10 (max)
 
@@ -184,7 +184,7 @@ class TestAggregateTrades:
             maker_flags=[True, False, True],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
         row = result.iloc[0]
 
         assert row['open_liquidity'] == pytest.approx(200.0)   # 100 * 2
@@ -208,7 +208,7 @@ class TestAggregateTrades:
             maker_flags=[False, False],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
         assert result.iloc[0]['std'] == pytest.approx(expected_pop_std, abs=1e-6)
         assert result.iloc[0]['std'] != pytest.approx(expected_sample_std, abs=0.1)
 
@@ -223,7 +223,7 @@ class TestAggregateTrades:
             maker_flags=[True],
         )
 
-        result = _aggregate_trades(trades, kline_size=1)
+        result = aggregate_trades(trades, kline_size=1)
         assert list(result.columns) == KLINE_COLUMNS
         assert result['datetime'].dt.tz is not None  # UTC-aware
         assert result['no_of_trades'].dtype == np.int64

--- a/binancial/compute/tests/test_spot_kline_cache.py
+++ b/binancial/compute/tests/test_spot_kline_cache.py
@@ -1,0 +1,171 @@
+"""Tests for SpotKlineCache."""
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from binancial.compute.spot_kline_cache import SpotKlineCache
+
+
+def _make_trades_df(start_id, count, base_price=50000.0, base_time_ms=1_700_000_000_000):
+    """Build a trades DataFrame mimicking get_trades_historical output.
+
+    `time` carries timezone-aware UTC datetime as get_trades_historical
+    returns; `trade_id` is monotonic int from `start_id`.
+    """
+    times = pd.to_datetime(
+        [base_time_ms + i * 1000 for i in range(count)],
+        unit='ms',
+        utc=True,
+    )
+    return pd.DataFrame({
+        'time': times,
+        'trade_id': list(range(start_id, start_id + count)),
+        'price': [base_price + i * 0.5 for i in range(count)],
+        'quantity': [0.001] * count,
+        'quote_quantity': [base_price * 0.001] * count,
+        'buyer_is_maker': [bool(i % 2) for i in range(count)],
+    })
+
+
+class TestInit:
+
+    def test_rejects_non_positive_kline_size(self):
+        with pytest.raises(ValueError, match='kline_size must be positive'):
+            SpotKlineCache(client=MagicMock(), kline_size=0)
+
+    def test_rejects_non_positive_n_rows(self):
+        with pytest.raises(ValueError, match='n_rows must be positive'):
+            SpotKlineCache(client=MagicMock(), kline_size=300, n_rows=0)
+
+
+class TestFirstFetchBackfills:
+
+    def test_first_fetch_uses_start_date_path(self):
+        """Initial fetch must call get_trades_historical with `start_date`,
+        not `last_trade_id`, because the buffer is empty."""
+
+        client = MagicMock()
+        cache = SpotKlineCache(client, symbol='BTCUSDT', kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.return_value = _make_trades_df(start_id=1000, count=10)
+            cache.fetch()
+
+        mock_fetch.assert_called_once()
+        kwargs = mock_fetch.call_args.kwargs
+        assert 'start_date' in kwargs
+        assert kwargs.get('last_trade_id') is None
+        assert kwargs['symbol'] == 'BTCUSDT'
+
+    def test_first_fetch_populates_buffer_and_last_trade_id(self):
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+            return_value=_make_trades_df(start_id=1000, count=10),
+        ):
+            cache.fetch()
+
+        assert cache.cached_trade_count == 10
+        assert cache.last_trade_id == 1009
+
+
+class TestSubsequentFetchIncremental:
+
+    def test_second_fetch_uses_last_trade_id_not_start_date(self):
+        """Pin: after the buffer is populated, fetch() switches to the
+        `last_trade_id` path so it pulls only NEW trades, not the
+        full window again."""
+
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.side_effect = [
+                _make_trades_df(start_id=1000, count=10),
+                _make_trades_df(start_id=1010, count=5, base_time_ms=1_700_000_010_000),
+            ]
+            cache.fetch()
+            cache.fetch()
+
+        assert mock_fetch.call_count == 2
+        second_kwargs = mock_fetch.call_args_list[1].kwargs
+        assert second_kwargs.get('last_trade_id') == 1009
+        assert second_kwargs.get('start_date') is None
+
+    def test_incremental_fetch_appends_new_trades(self):
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.side_effect = [
+                _make_trades_df(start_id=1000, count=10),
+                _make_trades_df(start_id=1010, count=5, base_time_ms=1_700_000_010_000),
+            ]
+            cache.fetch()
+            cache.fetch()
+
+        assert cache.cached_trade_count == 15
+        assert cache.last_trade_id == 1014
+
+    def test_empty_incremental_fetch_keeps_buffer(self):
+        """A no-new-trades response must not blow away the existing buffer."""
+
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.side_effect = [
+                _make_trades_df(start_id=1000, count=10),
+                pd.DataFrame(),
+            ]
+            cache.fetch()
+            cache.fetch()
+
+        assert cache.cached_trade_count == 10
+        assert cache.last_trade_id == 1009
+
+
+class TestTrimCache:
+
+    def test_trim_drops_trades_outside_window(self):
+        """After append, trades older than `n_rows * kline_size` seconds
+        from the newest trade must be dropped."""
+
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=60, n_rows=2)
+
+        old_trades = _make_trades_df(
+            start_id=1000, count=5, base_time_ms=1_700_000_000_000,
+        )
+        new_trades = _make_trades_df(
+            start_id=1005, count=5, base_time_ms=1_700_000_500_000,
+        )
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.side_effect = [old_trades, new_trades]
+            cache.fetch()
+            cache.fetch()
+
+        assert cache.cached_trade_count == 5
+        assert cache.last_trade_id == 1009
+
+
+class TestEmptyState:
+
+    def test_last_trade_id_none_when_buffer_empty(self):
+        cache = SpotKlineCache(client=MagicMock(), kline_size=300, n_rows=100)
+        assert cache.last_trade_id is None
+        assert cache.cached_trade_count == 0

--- a/binancial/compute/tests/test_spot_kline_cache.py
+++ b/binancial/compute/tests/test_spot_kline_cache.py
@@ -169,3 +169,34 @@ class TestEmptyState:
         cache = SpotKlineCache(client=MagicMock(), kline_size=300, n_rows=100)
         assert cache.last_trade_id is None
         assert cache.cached_trade_count == 0
+
+    def test_empty_first_backfill_re_enters_backfill_on_next_fetch(self):
+        """Pin: if the initial backfill returns an empty DataFrame, the
+        next `fetch()` call must re-enter the start_date backfill path
+        rather than the last_trade_id incremental path (which would
+        crash because the buffer has no rows to read `trade_id` from).
+        """
+
+        client = MagicMock()
+        cache = SpotKlineCache(client, kline_size=300, n_rows=100)
+
+        with patch(
+            'binancial.compute.spot_kline_cache.get_trades_historical',
+        ) as mock_fetch:
+            mock_fetch.side_effect = [
+                pd.DataFrame(),
+                _make_trades_df(start_id=2000, count=4),
+            ]
+            cache.fetch()
+            assert cache.cached_trade_count == 0
+            assert cache.last_trade_id is None
+
+            cache.fetch()
+
+        assert mock_fetch.call_count == 2
+        # Second call must use the start_date path again, NOT last_trade_id
+        second_kwargs = mock_fetch.call_args_list[1].kwargs
+        assert 'start_date' in second_kwargs
+        assert second_kwargs.get('last_trade_id') is None
+        assert cache.cached_trade_count == 4
+        assert cache.last_trade_id == 2003

--- a/binancial/data/get_trades_historical.py
+++ b/binancial/data/get_trades_historical.py
@@ -84,11 +84,16 @@ def get_trades_historical(client: Any,
     end_date | str | datetime in 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS' format
     last_trade_id | int | resume pagination from `last_trade_id + 1`,
                           bypassing the `start_date` lookup. Mutually
-                          exclusive with `start_date`. Lets a caller
-                          who already has a rolling trade buffer pull
-                          only the newly-arrived trades since the
-                          previous fetch instead of re-walking the
-                          full history window every cycle
+                          exclusive with `start_date` (passing both
+                          raises `ValueError`); composes with `end_date`
+                          (pagination starts from `last_trade_id + 1`
+                          and stops on the first trade past `end_ms`,
+                          same as the `start_date` + `end_date` path).
+                          Lets a caller who already has a rolling
+                          trade buffer pull only the newly-arrived
+                          trades since the previous fetch instead of
+                          re-walking the full history window every
+                          cycle
     '''
 
     if start_date is not None and last_trade_id is not None:

--- a/binancial/data/get_trades_historical.py
+++ b/binancial/data/get_trades_historical.py
@@ -72,7 +72,8 @@ def get_trades_historical(client: Any,
                           symbol: str = "BTCUSDT",
                           limit: int = 1000,
                           start_date: str | None = None,
-                          end_date: str | None = None) -> pd.DataFrame:
+                          end_date: str | None = None,
+                          last_trade_id: int | None = None) -> pd.DataFrame:
 
     '''Returns historical trades for a given symbol
 
@@ -81,10 +82,25 @@ def get_trades_historical(client: Any,
     limit | int | number of trades to fetch (can exceed 1000)
     start_date | str | datetime in 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS' format
     end_date | str | datetime in 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS' format
+    last_trade_id | int | resume pagination from `last_trade_id + 1`,
+                          bypassing the `start_date` lookup. Mutually
+                          exclusive with `start_date`. Lets a caller
+                          who already has a rolling trade buffer pull
+                          only the newly-arrived trades since the
+                          previous fetch instead of re-walking the
+                          full history window every cycle
     '''
 
-    # Resolve the starting trade ID from start_date if provided
-    from_id = _resolve_start_id(client, symbol, start_date) if start_date else None
+    if start_date is not None and last_trade_id is not None:
+        raise ValueError('Pass start_date OR last_trade_id, not both')
+
+    # Resolve the starting trade ID from start_date / last_trade_id (or None)
+    if last_trade_id is not None:
+        from_id = last_trade_id + 1
+    elif start_date is not None:
+        from_id = _resolve_start_id(client, symbol, start_date)
+    else:
+        from_id = None
 
     # Resolve end_date to a millisecond timestamp for filtering
     end_ms = _parse_datetime_ms(end_date) if end_date else None

--- a/binancial/data/tests/test_get_trades_historical.py
+++ b/binancial/data/tests/test_get_trades_historical.py
@@ -191,3 +191,38 @@ def test_get_trades_historical_end_date_stops_pagination(mock_client):
     # batch_1 all within range, batch_2 all filtered -> stops pagination
     assert len(result) == 1000
     assert mock_client.get_historical_trades.call_count == 2
+
+
+def test_get_trades_historical_last_trade_id_skips_resolve(mock_client):
+    """`last_trade_id` bypasses `_resolve_start_id` and starts pagination
+    from `last_trade_id + 1` directly. Caller use case: rolling trade
+    cache pulling only newly-arrived trades since the prior fetch.
+    """
+
+    batch = [_make_trade(2001 + i, 100, 1, 1_700_000_000_000 + i, False) for i in range(3)]
+    mock_client.get_historical_trades.return_value = batch
+
+    result = get_trades_historical(
+        mock_client, last_trade_id=2000, limit=3,
+    )
+
+    # _resolve_start_id (which calls get_aggregate_trades) must NOT be called
+    mock_client.get_aggregate_trades.assert_not_called()
+
+    # First (and only) historical_trades call must use fromId = last_trade_id + 1
+    first_call_kwargs = mock_client.get_historical_trades.call_args_list[0].kwargs
+    assert first_call_kwargs['fromId'] == 2001
+    assert len(result) == 3
+
+
+def test_get_trades_historical_rejects_both_start_date_and_last_trade_id(mock_client):
+    """Mutually exclusive params raise rather than silently picking one."""
+
+    with pytest.raises(ValueError, match='start_date OR last_trade_id'):
+        get_trades_historical(
+            mock_client, start_date='2025-01-01', last_trade_id=42,
+        )
+
+    # Neither client method should have been invoked on the rejection
+    mock_client.get_aggregate_trades.assert_not_called()
+    mock_client.get_historical_trades.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "binancial"
-version = "0.2.2"
+version = "0.3.0"
 description = "A Binance API-wrapper that brings all klines and trades data end-points to single-line commands."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

Adds `SpotKlineCache` (`binancial/compute/spot_kline_cache.py`) — a stateful kline cache designed for periodic live polling. The first `fetch()` backfills the rolling trade buffer from `now - n_rows * kline_size` via `get_trades_historical`'s `start_date` path; every subsequent `fetch()` only pulls trades newer than the cached `last_trade_id`. This collapses per-fetch network cost from hundreds of paginated `/api/v3/historicalTrades` calls (one per 1000 trades over the full window) to ~1 call per cycle (the few hundred trades that arrived since the previous fetch). The trade buffer is trimmed to the `n_rows * kline_size` time window after each append so memory stays bounded. Supports the same 19-column kline output as `get_spot_klines` since it reuses `_aggregate_trades` + `_drop_partial_kline` internally.

Also adds a `last_trade_id` parameter to `get_trades_historical`: when provided, pagination starts from `last_trade_id + 1` (mirroring the existing internal off-by-one) and `_resolve_start_id` is bypassed entirely. Mutually exclusive with `start_date` — passing both raises `ValueError`. Backwards-compatible: callers passing only `start_date` (or neither) are unaffected.

**Why:** Praxis's `MarketDataPoller` calls `get_spot_klines` on every poll cycle, which under the hood walks the full `n_rows * kline_size` window of raw trades via 1000-row paged calls. For a 1100-bar 5m kline window (~5.7 days), that's 50-150+ HTTP round-trips per fetch on BTCUSDT testnet, hitting the per-IP weight limit and tripping `RateLimitError`. The SFD's `RAW_MARKET_COLUMNS` (16 of the 19 binancial columns including `maker_volume`, `liquidity_sum`, per-bar liquidity decomposition) cannot be reconstructed from Binance's native `/api/v3/klines` endpoint, so we have to keep aggregating from raw trades — but we don't have to re-fetch the entire window every cycle. `SpotKlineCache` is the surgical fix for that.

49 tests passing (8 new), ruff clean. Bumps to v0.3.0.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran \`python -m pytest\` locally without errors (49 passed)
- [ ] I updated \`/docs\` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123") when applicable